### PR TITLE
Fix URL to configs

### DIFF
--- a/src/org/rossabaker.org
+++ b/src/org/rossabaker.org
@@ -1018,7 +1018,7 @@ Define the menu in the config:
 
   [[menu.main]]
   name = 'Configs'
-  url = '/talks'
+  url = '/configs'
   weight = 140
 
   [[menu.main]]


### PR DESCRIPTION
The "configs" URL was pointing to talks instead.